### PR TITLE
Allow relative paths for opening Mathcad sheets

### DIFF
--- a/MathcadPy/_application.py
+++ b/MathcadPy/_application.py
@@ -88,7 +88,7 @@ class Mathcad:
     def open(self, filepath: Path):
         """Opens the filepath (if valid) in Mathcad"""
         try:
-            filepath = Path(filepath)
+            filepath = Path(filepath).resolve()
             if not filepath.exists():
                 raise FileNotFoundError()
             if filepath.suffix.lower() != ".mcdx":


### PR DESCRIPTION
Issue solved by resolving the path passed to `Mathcad.open` into an absolute and resolved path. The `setup.py` says that this package supports Python 3.5 and above. This solution works for these python versions. If the passed path does not exist, in python 3.5 a `FileNotFoundError` will be raised in the modified line. In later versions, the same error will be raised after the explicit check for the path's existence fails. 